### PR TITLE
Added support for multiple currencies

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ password  = "xxxx"
 send_to   = "xxx@xxx.comm"
 
 # currency you want to use
+# Options options can be found at https://blockchain.info/ticker
 currency  = "CHN"
 
 # if the price is higher than "high" or less than "low"

--- a/config.py
+++ b/config.py
@@ -11,6 +11,9 @@ password  = "xxxx"
 # it can be same with the sending email
 send_to   = "xxx@xxx.comm"
 
+# currency you want to use
+currency  = "CHN"
+
 # if the price is higher than "high" or less than "low"
 # it will warn
 high      = 4200

--- a/main.py
+++ b/main.py
@@ -3,11 +3,16 @@ import mail
 import simplejson
 import urllib2
 import time
-
+from config import *
 
 def moniter(m, send_to, high, low):
 
-    req = urllib2.Request("https://data.btcchina.com/data/ticker")
+    if currency == 'CHN':
+        url = 'http://data.btcchina.com/data/ticker'
+    else:
+        url = 'https://blockchain.info/ticker'
+
+    req = urllib2.Request(url)
     opener = urllib2.build_opener()
     last_sent = 0
 
@@ -19,7 +24,17 @@ def moniter(m, send_to, high, low):
             time.sleep(3)
             continue
 
-        price = float(data['ticker']['last'])
+        if currency == 'CHN':
+            price = float(data['ticker']['last'])
+            buy = data['ticker']['buy']
+            sell = data['ticker']['sell']
+            symbol = '￥'
+        else:
+            price = float(data[currency]['last'])
+            buy = str(data[currency]['buy'])
+            sell = str(data[currency]['sell'])
+            symbol = str(data[currency]['symbol'])
+
         if price > high or price < low:
             if time.time() - last_sent > 5 * 60:
                 try:
@@ -30,10 +45,9 @@ def moniter(m, send_to, high, low):
                 except Exception, e:
                     print e
 
-        print "Price: ￥%s  Buy: ￥%s  Sell: ￥%s" % (data['ticker']['last'],
-                    data['ticker']['buy'], data['ticker']['sell'])
+        print("Price: " + symbol + str(price) + " Buy: " + symbol + buy + "  Sell: " + symbol + sell)
         time.sleep(3)
-        
+
 if __name__ == "__main__":
     m = mail.Mail(account, smtp_addr, account, password)
     moniter(m, send_to, high, low)

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import urllib2
 import time
 from config import *
 
+
 def moniter(m, send_to, high, low):
 
     if currency == 'CHN':
@@ -38,14 +39,15 @@ def moniter(m, send_to, high, low):
         if price > high or price < low:
             if time.time() - last_sent > 5 * 60:
                 try:
-                    m.send(send_to, "BTC Ticker Warning", 
+                    m.send(send_to, "BTC Ticker Warning",
                            "the price now is " + str(price))
                     print "sent email"
                     last_sent = time.time()
                 except Exception, e:
                     print e
 
-        print("Price: " + symbol + str(price) + " Buy: " + symbol + buy + "  Sell: " + symbol + sell)
+        print("Price: " + symbol + str(price) + " Buy: " + symbol + buy +
+              "  Sell: " + symbol + sell)
         time.sleep(3)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I added support for 20 new currencies. They are pulled from https://blockchain.info/ticker. It does not update as often as BTC China but still works. Currency is selected through the config.py file.

For example:
`currency = 'USD'`
This will grab the USD information from blockchain.info

Although blockchain.info supports Chinese BTC prices, I left your original url when CHN is selected as the currency. BTC China is still the default.